### PR TITLE
update dev settings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,10 +17,6 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get update && apt-get install -y openjdk-17-jdk \
     && rm -rf /var/lib/apt/lists/*
 
-# Set JAVA_HOME environment variable
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-ENV PATH=$JAVA_HOME/bin:$PATH
-
 # Create a virtual environment to avoid PEP 668 error https://peps.python.org/pep-0668/
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,10 @@
             "extensions": [
                 "ms-python.python",
                 "ms-python.vscode-pylance"
-            ]
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/opt/venv/bin/python"
+            }
         }
     },
     "remoteUser": "root",


### PR DESCRIPTION
#32  Removes the `ENV JAVA_HOME` which works on both macOS and windows.
#33  Adds the defaultInterpreterPath when working in Dev Container