### PR TITLE
Update on Isolation storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Writing code isn’t the only way to contribute. You can also:
 
 - review pull requests
 - suggest improvements through issues
-- let us know your painpoints and repeatitive tasks
+- let us know your pain-points and repetitive tasks
 - help us stay on top of new and old issues
 - develop tutorials, videos, presentations, and other educational materials
 
@@ -25,7 +25,13 @@ Jorvik is available in Pypi and can be installed with pip
 pip install jorvik
 ```
 
-Packages:
+### Packages:
 - [Storage](https://github.com/jorvik-io/jorvik/blob/main/jorvik/storage/README.md): Interact with the storage layer
 - [Pipelines](https://github.com/jorvik-io/jorvik/blob/main/jorvik/pipelines/README.md): Build and test etl pipelines with ease
 - [Data Lineage](https://github.com/jorvik-io/jorvik/blob/main/jorvik/data_lineage/README.md): Track data lineage
+
+### Examples:
+See the full power of jorvik when all the features come together in the examples bellow:
+#### Databricks
+
+- [Transactions](https://github.com/jorvik-io/jorvik/blob/main/examples/databricks/transactions/README.md): A multi step pipeline that creates customer statistics from customers and transaction data.

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,6 @@
         "pytest",
         "isin",
         "dbfs",
-        "featureisolation"
+        "Pypi"
     ]
 }

--- a/jorvik/storage/README.md
+++ b/jorvik/storage/README.md
@@ -93,10 +93,10 @@ If your mount point is not named `mnt`. Set `io.jorvik.storage.mount_point` to y
 Working example:
 
 * Working in Databricks on a checked out branch named `feature-branch`
-* isolation_folder is set to "featureisolation" through `spark.conf.set("io.jorvik.storage.isolation_folder", "featureisolation")`
+* isolation_folder is set to "isolation" through `spark.conf.set("io.jorvik.storage.isolation_folder", "isolation")`
 * data path: `/mnt/prod_storage/silver/foo/bar`
 
-The isolated path will be configured to `/mnt/featureisolation/feature-branch/prod_storage/silver/foo/bar`
+The isolated path will be configured to `/mnt/isolation/feature-branch/prod_storage/silver/foo/bar`
 
 * st.write(df, data_path, format="delta", mode="overwrite") will always write to the configured path.
 * st.read(df, data_path, format="delta") will read from the configured path if it exists. Else the regular path.

--- a/jorvik/storage/isolation.py
+++ b/jorvik/storage/isolation.py
@@ -47,7 +47,7 @@ class IsolatedStorage():
         if not mount_point.startswith("/"):
             mount_point = "/" + mount_point
 
-        isolation_folder = spark.conf.get("io.jorvik.storage.isolation_folder", "isolation").strip("/") or ""
+        isolation_folder = spark.conf.get("io.jorvik.storage.isolation_folder", "jorvik_isolation").strip("/") or ""
         mounted_isolation_folder = os.path.join(mount_point, isolation_folder)
         if not self.storage.exists(mounted_isolation_folder):
             raise RuntimeError(f"Isolation folder: {mounted_isolation_folder} does not exist! Have you mounted it?")

--- a/jorvik/storage/isolation.py
+++ b/jorvik/storage/isolation.py
@@ -40,24 +40,23 @@ class IsolatedStorage():
         """
         spark = SparkSession.getActiveSession()
 
-        if not spark.conf.get("io.jorvik.storage.mount_point", None):
+        mount_point = spark.conf.get("io.jorvik.storage.mount_point", "").rstrip("/")
+        if not mount_point:
             mount_point = "/mnt"
-        else:
-            mount_point = spark.conf.get("io.jorvik.storage.mount_point")
-
-        if not mount_point.endswith("/"):
-            mount_point = mount_point + "/"
 
         if not mount_point.startswith("/"):
             mount_point = "/" + mount_point
 
-        isolation_folder = spark.conf.get("io.jorvik.storage.isolation_folder").strip("/") or ""
+        isolation_folder = spark.conf.get("io.jorvik.storage.isolation_folder", "isolation").strip("/") or ""
+        mounted_isolation_folder = os.path.join(mount_point, isolation_folder)
+        if not self.storage.exists(mounted_isolation_folder):
+            raise RuntimeError(f"Isolation folder: {mounted_isolation_folder} does not exist! Have you mounted it?")
         isolation_context = self.isolation_provider().strip("/") or ""
 
         iso_sub_path = os.path.join(isolation_folder, isolation_context) + "/"
 
         # Replace the mount point with the isolation folder and context
-        full_isolation_path = path.replace(mount_point, mount_point + iso_sub_path)
+        full_isolation_path = path.replace(mount_point, os.path.join(mount_point, iso_sub_path))
 
         # Ensure single slashes
         full_isolation_path = re.sub('/+', '/', full_isolation_path)

--- a/test/storage/test_isolation.py
+++ b/test/storage/test_isolation.py
@@ -44,7 +44,6 @@ def mock_spark_conf():
         mock_spark_session.getActiveSession.return_value = mock_spark
         yield mock_spark
 
-
 @pytest.mark.parametrize(
     "mount_point, isolation_folder, isolation_context, input_path, expected",
     [
@@ -57,13 +56,14 @@ def mock_spark_conf():
     ]
 )
 def test_create_isolation_path(mock_spark_conf, mount_point, isolation_folder, isolation_context, input_path, expected):
-    mock_spark_conf.conf.get.side_effect = lambda key, default=None: {
-        "io.jorvik.storage.mount_point": mount_point,
-        "io.jorvik.storage.isolation_folder": isolation_folder,
-    }.get(key, default)
+    with patch("jorvik.storage.BasicStorage.exists"):
+        mock_spark_conf.conf.get.side_effect = lambda key, default=None: {
+            "io.jorvik.storage.mount_point": mount_point,
+            "io.jorvik.storage.isolation_folder": isolation_folder,
+        }.get(key, default)
 
-    storage = IsolatedStorage(storage=BasicStorage(), isolation_provider=lambda: isolation_context)
-    assert storage._create_isolation_path(input_path) == expected
+        storage = IsolatedStorage(storage=BasicStorage(), isolation_provider=lambda: isolation_context)
+        assert storage._create_isolation_path(input_path) == expected
 
 
 @pytest.mark.parametrize(

--- a/test/storage/test_storage.py
+++ b/test/storage/test_storage.py
@@ -1,0 +1,37 @@
+from pytest_mock import MockerFixture
+
+from jorvik import storage
+from jorvik.storage import BasicStorage
+from jorvik.storage.isolation import IsolatedStorage
+
+
+def test_configure_with_isolation_provider(mocker: MockerFixture):
+    """ Setting Isolation Provider should be enough to configure Isolated Storage. """
+    mocker.patch("jorvik.storage.BasicStorage.exists")
+    mocker.patch("jorvik.storage.SparkSession")
+    spark = mocker.patch("jorvik.storage.isolation.SparkSession")
+    spark.getActiveSession().conf = {}
+
+    st = storage.configure(lambda: "my_feature")
+    assert st._create_isolation_path("/mnt/my_table/data") == "/mnt/isolation/my_feature/my_table/data"
+
+
+def test_configure_no_arguments_no_config(mocker: MockerFixture):
+    mocker.patch("jorvik.storage.SparkSession")
+    mocker.patch("jorvik.storage.isolation_providers.get_spark_config", return_value="NO_ISOLATION")
+    st = storage.configure()
+    assert isinstance(st, BasicStorage)
+
+
+def test_configure_with_config(mocker: MockerFixture):
+    mocker.patch("jorvik.storage.SparkSession")
+    mocker.patch("jorvik.storage.isolation_providers.get_spark_config", return_value="SPARK_CONFIG")
+    st = storage.configure()
+    assert isinstance(st, IsolatedStorage)
+
+
+def test_configure_with_track_lineage(mocker: MockerFixture):
+    mocker.patch("jorvik.storage.SparkSession")
+    mocker.patch("jorvik.storage.isolation_providers.get_spark_config", return_value="NO_ISOLATION")
+    st = storage.configure(track_lineage=True)
+    assert len(st.output_observers) == 1

--- a/test/storage/test_storage.py
+++ b/test/storage/test_storage.py
@@ -13,7 +13,7 @@ def test_configure_with_isolation_provider(mocker: MockerFixture):
     spark.getActiveSession().conf = {}
 
     st = storage.configure(lambda: "my_feature")
-    assert st._create_isolation_path("/mnt/my_table/data") == "/mnt/isolation/my_feature/my_table/data"
+    assert st._create_isolation_path("/mnt/my_table/data") == "/mnt/jorvik_isolation/my_feature/my_table/data"
 
 
 def test_configure_no_arguments_no_config(mocker: MockerFixture):


### PR DESCRIPTION
- Revisit storage.configure
- Added default for isolation folder and throw an error if the folder is not mounted so storage.configure(databrick.get_active_branch) defines a working Isolated storage no matter the spark configuration
- Added link to examples in ReadMe
